### PR TITLE
repeated the outer component in main container

### DIFF
--- a/src/app/main-container/main-container.component.html
+++ b/src/app/main-container/main-container.component.html
@@ -3,4 +3,5 @@
   <span>names list: {{names}}</span><br>
   <span>Selected name: {{name}}</span>
   <app-outer-container [names]="names" (eventFromOuter)="eventFromOuter($event)"></app-outer-container>
+  <app-outer-container [names]="names" (eventFromOuter)="eventFromOuter($event)"></app-outer-container>
 </div>


### PR DESCRIPTION
In the main container's template, repeated the outer component tag. Whenever the send to outer component button is clicked, it will send the name only to its outer component.